### PR TITLE
Update bufferwithtolerance-geometry-data-type.md

### DIFF
--- a/docs/t-sql/spatial-geometry/bufferwithtolerance-geometry-data-type.md
+++ b/docs/t-sql/spatial-geometry/bufferwithtolerance-geometry-data-type.md
@@ -49,7 +49,7 @@ Restituisce un oggetto geometrico che rappresenta l'unione dei valori di tutti i
  La distanza ideale del buffer di un punto ad esempio è un cerchio, che però deve essere approssimato da un poligono. Minore è il valore della tolleranza, maggiore sarà il numero di punti del poligono. In questo caso aumenterà la complessità del risultato, ma diminuirà l'errore.  
   
  *relative*  
- Valore **bit** che specifica se il valore *tolerance* è relativo o assoluto. Se il valore è TRUE o 1, la tolleranza è relativa e viene calcolata come prodotto tra il parametro *tolerance* e il diametro del rettangolo di selezione dell'istanza. Se il valore è FALSE o 0, la tolleranza è assoluta e il valore *tolerance* è la variazione massima assoluta nella distanza ideale del buffer per l'approssimazione lineare restituita.  
+ Valore **bit** che specifica se il valore *tolerance* è relativo o assoluto. Se il valore è TRUE o 1, la tolleranza è relativa e viene calcolata come prodotto tra il parametro *tolerance* e il diametro del rettangolo di contenimento dell'istanza. Se il valore è FALSE o 0, la tolleranza è assoluta e il valore *tolerance* è la variazione massima assoluta nella distanza ideale del buffer per l'approssimazione lineare restituita.  
   
 ## <a name="return-types"></a>Tipi restituiti  
  Tipo [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] restituito: **geometry**  


### PR DESCRIPTION
I think that a bounding box represents the smallest rectangle that contains the feature and not the rectangle thar can select the feature dragging on it a rectangular area. So the correct italian word is "contenimento" and not "selezione". What do you think ? 